### PR TITLE
✨feature/댓글 등록

### DIFF
--- a/src/main/java/study/supercoding_1/controller/CommentController.java
+++ b/src/main/java/study/supercoding_1/controller/CommentController.java
@@ -1,4 +1,28 @@
 package study.supercoding_1.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import study.supercoding_1.dto.AddCommentDTO;
+import study.supercoding_1.service.CommentService;
+
+@Controller
+@RequestMapping("/api")
+@RequiredArgsConstructor
 public class CommentController {
+    private final CommentService commentService;
+
+    @ResponseBody
+    @PostMapping("/comments")
+    @Operation(summary = "댓글 작성",description = "새로운 댓글을 작성합니다.")
+    public ResponseEntity<String> addComment(@RequestBody AddCommentDTO addCommentDTO){
+        commentService.addComment(addCommentDTO);
+        return ResponseEntity.ok("성공");
+    }
+
 }

--- a/src/main/java/study/supercoding_1/dto/AddCommentDTO.java
+++ b/src/main/java/study/supercoding_1/dto/AddCommentDTO.java
@@ -1,0 +1,9 @@
+package study.supercoding_1.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AddCommentDTO {
+    private String content;
+    private String author;
+}

--- a/src/main/java/study/supercoding_1/entity/Comment.java
+++ b/src/main/java/study/supercoding_1/entity/Comment.java
@@ -1,0 +1,32 @@
+package study.supercoding_1.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "comments")
+@NoArgsConstructor
+//@ToString(exclude = {"id","user","post"})
+public class Comment extends BaseTimeEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String content;
+    private String author;
+
+    @Builder
+    public Comment(String content, String author) {
+        this.content = content;
+        this.author = author;
+    }
+
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id")
+//    private User user;
+
+//    @ManyToOne
+//    @JoinColumn(name = "post_id")
+//    private Post post;
+}

--- a/src/main/java/study/supercoding_1/repository/CommentRepository.java
+++ b/src/main/java/study/supercoding_1/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package study.supercoding_1.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import study.supercoding_1.entity.Comment;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+}

--- a/src/main/java/study/supercoding_1/service/CommentService.java
+++ b/src/main/java/study/supercoding_1/service/CommentService.java
@@ -1,0 +1,21 @@
+package study.supercoding_1.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import study.supercoding_1.dto.AddCommentDTO;
+import study.supercoding_1.entity.Comment;
+import study.supercoding_1.repository.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    public void addComment(AddCommentDTO addCommentDTO){
+        Comment newComment = Comment.builder()
+                .content(addCommentDTO.getContent())
+                .author(addCommentDTO.getAuthor())
+                .build();
+        commentRepository.save(newComment);
+    }
+}


### PR DESCRIPTION
## Comment 엔티티 구현
* 댓글을 저장하기 위한 엔티티를 구현하였습니다.
* Post와 User 엔티티와의 연관관계는 현재 주석처리 해놓았고, 해당 엔티티 구현 후 수정될 예정입니다.
* ToString 애노테이션의 주석처리는 다른 엔티티 구현 후 수정될 예정입니다.

## AddComment 기능 구현
새로운 댓글을 등록하기 위한 addComment를 구현했습니다. 요청을 통해 받은 작성자, 댓글 내용이 DB에 Insert 됩니다.

__향후 개선사항__
* 로그인된 사용자만이 댓글 등록이 가능하도록 구현
* User 엔티티, Post 엔티티와 연관관계를 통해 각각의 id가 DB의 comments 컬럼에 같이 들어가도록 구현

closes #19 