### PR TITLE
🐛fix:AddComment 관련된 내용 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3' // API
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3' // 구현
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3' // JSON 처리
+
+    //Test 롬복
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/study/supercoding_1/dto/AddCommentDTO.java
+++ b/src/main/java/study/supercoding_1/dto/AddCommentDTO.java
@@ -1,9 +1,12 @@
 package study.supercoding_1.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class AddCommentDTO {
     private String content;
     private String author;
+    private String post_id;
 }

--- a/src/main/java/study/supercoding_1/entity/Comment.java
+++ b/src/main/java/study/supercoding_1/entity/Comment.java
@@ -6,7 +6,8 @@ import lombok.*;
 @Entity
 @Table(name = "comments")
 @NoArgsConstructor
-//@ToString(exclude = {"id","user","post"})
+@Getter
+@ToString(exclude = {"id","user","post"})
 public class Comment extends BaseTimeEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -16,17 +17,17 @@ public class Comment extends BaseTimeEntity{
     private String author;
 
     @Builder
-    public Comment(String content, String author) {
+    public Comment(String content, String author,Posts post) {
         this.content = content;
         this.author = author;
+        this.post = post;
     }
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "user_id")
-//    private User user;
-
-//    @ManyToOne
-//    @JoinColumn(name = "post_id")
-//    private Post post;
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Posts post;
 }

--- a/src/main/java/study/supercoding_1/service/CommentService.java
+++ b/src/main/java/study/supercoding_1/service/CommentService.java
@@ -1,21 +1,35 @@
 package study.supercoding_1.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import study.supercoding_1.dto.AddCommentDTO;
 import study.supercoding_1.entity.Comment;
+import study.supercoding_1.entity.Posts;
 import study.supercoding_1.repository.CommentRepository;
+import study.supercoding_1.repository.PostsRepository;
+import study.supercoding_1.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
-    private final CommentRepository commentRepository;
 
-    public void addComment(AddCommentDTO addCommentDTO){
+    private final CommentRepository commentRepository;
+    private final PostsRepository postsRepository;
+
+    @Transactional
+    public Comment addComment(AddCommentDTO addCommentDTO){
+
+        Posts post = postsRepository.findById(Integer.valueOf(addCommentDTO.getPost_id()))
+                .orElseThrow(()->new RuntimeException("server error"));
+
         Comment newComment = Comment.builder()
                 .content(addCommentDTO.getContent())
                 .author(addCommentDTO.getAuthor())
+                .post(post)
                 .build();
-        commentRepository.save(newComment);
+
+        return commentRepository.save(newComment);
     }
 }

--- a/src/test/java/study/supercoding_1/service/CommentServiceTest.java
+++ b/src/test/java/study/supercoding_1/service/CommentServiceTest.java
@@ -1,0 +1,48 @@
+package study.supercoding_1.service;
+
+import jakarta.persistence.Column;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import study.supercoding_1.dto.AddCommentDTO;
+import study.supercoding_1.entity.Comment;
+import study.supercoding_1.entity.Posts;
+import study.supercoding_1.repository.PostsRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Slf4j
+class CommentServiceTest {
+
+    @Autowired
+    private CommentService commentService;
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @Test
+    void addComment() {
+        //given
+        String cContent = "내용입니다1";
+        String cAuthor = "홍길동";
+        Posts posts = Posts.builder()
+                .title("포스트제목")
+                .content("포스트내용입니다.")
+                .author("이순신")
+                .build();
+        Posts savedPost = postsRepository.save(posts);
+
+        AddCommentDTO addCommentDTO = new AddCommentDTO(cContent,cAuthor,String.valueOf(savedPost.getId()));
+
+        //when
+        Comment savedComment = commentService.addComment(addCommentDTO);
+        log.info("댓글 내용 = {}",savedComment.getContent());
+
+        //then
+        Assertions.assertThat(savedComment.getAuthor()).isEqualTo(cAuthor);
+
+
+    }
+}


### PR DESCRIPTION
## 수정 내용
* AddCommentDTO 에 post_id 필드를 추가하고, 생성자를 추가했습니다.
* Comment 엔티티에 getter 추가, 연관관계 설정 필드 주석을 제거했습니다.
* addComment의 로직을 요구사항에 맞게 수정했습니다.
## 추가 내용
* AddCommentService 의 addComment 메소드를 테스트했습니다.
* build.gradle 에 테스트 코드에서 사용 가능한 Lombok 라이브러리를 추가했습니다.

closes #26 