### PR TITLE
🐛 fix:댓글 생성, 수정시 오류 발생 해결

### DIFF
--- a/src/main/java/study/supercoding_1/dto/AddCommentRequest.java
+++ b/src/main/java/study/supercoding_1/dto/AddCommentRequest.java
@@ -1,12 +1,17 @@
 package study.supercoding_1.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 public class AddCommentRequest {
     private String content;
     private String author;
-    private int post_id;
+    @JsonProperty("post_id")
+    private int postId;
 }

--- a/src/main/java/study/supercoding_1/dto/UpdateCommentRequest.java
+++ b/src/main/java/study/supercoding_1/dto/UpdateCommentRequest.java
@@ -2,9 +2,11 @@ package study.supercoding_1.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class UpdateCommentRequest {
     private String content;
 }


### PR DESCRIPTION
## 문제 내용
* 댓글 생성시 post_id 데이터를 받아올 수 없어서 그에 따른 오류 발생 (500)
* 댓글 수정시 json데이터를 parsing 할 수 없던 오류 발생 (400)

## 해결 내용
* AddCommentRequest 의 postId 필드를 JsonProperty 로 지정
* UpdateCommentRequest 에 기본 생성자 어노테이션 추가